### PR TITLE
Added quiet flag to wget command.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,7 @@ mkdir /opt/redis
 
 cd /opt/redis
 # Use latest stable
-wget http://download.redis.io/redis-stable.tar.gz
+wget -q http://download.redis.io/redis-stable.tar.gz
 # Only update newer files
 tar -xz --keep-newer-files -f redis-stable.tar.gz
 


### PR DESCRIPTION
## What does this PR solves?
The `wget` call in `init.sh` cluttered the output with the progress information. Due to no carriage return without tty, the progress information was not written to a single line but many.

## What is the solution?
Added `-q` quiet flag to wget. 

## How should this be manually tested?
Clone a clean repo and run `vagrant up`. 

## Risk
None.